### PR TITLE
Sugiro adicionar "verify=False" (veja abaixo).

### DIFF
--- a/src/sidrapy/resources/handler.py
+++ b/src/sidrapy/resources/handler.py
@@ -69,7 +69,7 @@ def get(
         header,
     )
 
-    response = requests.get(url)
+    response = requests.get(url, verify=False)
 
     if not response.ok:
         raise ValueError(response.text)


### PR DESCRIPTION
De alguma forma, quando instalado no google colab, o sidra rejeita o request por falha na conexão SSL (veja um exemplo):
SSLError: HTTPSConnectionPool(host='apisidra.ibge.gov.br', port=443): Max retries exceeded with url: /values/t/1613/n6/3149804/p/1974-2020/v/2313,216,214,112 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1091)')))